### PR TITLE
Fix resetConsents function

### DIFF
--- a/src/OreosManager.php
+++ b/src/OreosManager.php
@@ -98,7 +98,11 @@ class OreosManager
     public function resetConsents()
     {
         CookieJar::queue(
-            CookieJar::forget( $this->getConfig('name') )
+            CookieJar::forget(
+                $this->getConfig('name'),
+                config('session.path'),
+                config('session.domain') ?? request()->getHost()
+            )
         );
     }
 


### PR DESCRIPTION
The `resetConsents` method and therefore the reset function was not working as expected.

`resetConsents` was setting an invalidated cookie to the domain "example.com" instead of ".example.com".
Using the same parameters as in the `saveConsents` method, will fix the issue and invalidate the right cookie.
